### PR TITLE
Update WcsGetCoverage1_0_0.java

### DIFF
--- a/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsGetCoverage1_0_0.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/ogc/wcs/wcs1_0_0/WcsGetCoverage1_0_0.java
@@ -30,8 +30,8 @@ public class WcsGetCoverage1_0_0 {
 		}
 		return false;
 	}
-	
-	public static String createWcsGetCoverageRequest(String layerName, CoverageOffering1_0_0 coverageOffering, BoundingBox bounds, int epsgCode, String outputFormat) throws Exception {
+	// BEN ADDED Envelope nativeBbox to method
+	public static String createWcsGetCoverageRequest(String layerName, CoverageOffering1_0_0 coverageOffering, BoundingBox bounds, int epsgCode, String outputFormat, BoundingBox nativeBbox) throws Exception {
 		//http://data.fao.org/maps/wcs?service=WCS&version=1.0.0&request=GetCoverage&coverage=lus_mna_31661&bbox=-13.166733,39.766613,12.099957,63.333236&crs=EPSG:4326&format=geotiff&width=917&height=331
 
 			List<String> supportedFormats = coverageOffering.getSupportedFormats();
@@ -46,53 +46,73 @@ public class WcsGetCoverage1_0_0 {
 			Hints hints = new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.TRUE);
 			CRSAuthorityFactory factory = ReferencingFactoryFinder.getCRSAuthorityFactory("EPSG", hints);
 			CoordinateReferenceSystem sourceCRS = factory.createCoordinateReferenceSystem("EPSG:4326");
-			
+		    //The bounding box is created in EPSG 4326.  The line below takes the corrdinates given and references to the sourceCRS (EPSG:4326).
+		    //The envelope is then transformed to the native (targetCRS) bounds below.		    
 		    ReferencedEnvelope envelope = new ReferencedEnvelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY(), sourceCRS);
 		    logger.info("requested Bounds: " + OgpUtils.referencedEnvelopeToString(envelope));
+		    
 		    // Transform using 10 sample points around the envelope
-
 		    CoordinateReferenceSystem targetCRS = factory.createCoordinateReferenceSystem(coverageOffering.getSupportedCRSs().get(0));
 
 		    ReferencedEnvelope result = envelope.transform(targetCRS, true, 10);
 
-		 String getCoverageRequest = "service=WCS&version=" + VERSION + 
+		// Pull min and max values from full coverage envelope
+		ReferencedEnvelope nativeRefEnv = new ReferencedEnvelope(nativeBbox.getMinX(), nativeBbox.getMaxX(), nativeBbox.getMinY(), nativeBbox.getMaxY(), targetCRS);
+		
+		Double resX = coverageOffering.getRectifiedGrid().getResx();  //Get X Resolution of Raster
+		Double resY = coverageOffering.getRectifiedGrid().getResy();  //Get Y Resolution of Raster
+
+		Double xMin, yMin, xMax, yMax;
+
+		// Sending a request for a bounding box which cut through pixels caused geotools to warp the coverage compromising the integrity and altering noData values
+		// This was an an issue 8 bit unsigned 4 band rasters which were having noData values set to 0 causing noData values to be read where r,g,b,i were something like 50,0,190,89
+		if ( nativeRefEnv.getMinimum(0) > result.getMinimum(0)){  //Checks if xMin is less than xMin of whole coverage.  If so, set xMin to xmin of whole coverage 
+			xMin = nativeRefEnv.getMinimum(0);  
+		} else {
+			// This will get the difference between xMin calculated from portal and the raster file and divide by the resolution along x axis to return the number of pixels between input bbox and actual coverage envelope
+			Double x_a = (Math.abs(result.getMinimum(0) - nativeRefEnv.getMinimum(0)))/resX;//
+			// Coverts pixel difference value to integer to get whole pixels, re-multiply by resolution to get whole number difference.  Add back to bounding box of whole coverage to set xMin.
+			xMin = nativeRefEnv.getMinimum(0) + (x_a.intValue() * resX);    }
+		
+		// Repeat xMin process for yMin
+		if ( nativeRefEnv.getMinimum(1) > result.getMinimum(1)){
+			yMin = nativeRefEnv.getMinimum(1);
+		} else {
+			Double y_a = (Math.abs(result.getMinimum(1) - nativeRefEnv.getMinimum(1)))/resY;
+			yMin = nativeRefEnv.getMinimum(1) + (y_a.intValue() * resY);    }
+
+		// Same as above for xMax and yMax, but subtract the whole number value width instead of adding.
+		if ( nativeRefEnv.getMaximum(0) < result.getMaximum(0)){
+			xMax = nativeRefEnv.getMaximum(0);
+		} else {
+			Double x_b = (Math.abs(result.getMaximum(0) - nativeRefEnv.getMaximum(0)))/resX;
+			xMax = nativeRefEnv.getMaximum(0) - (x_b.intValue() * resX);    }
+
+
+		if ( nativeRefEnv.getMaximum(1) < result.getMaximum(1)){
+			yMax = nativeRefEnv.getMaximum(1);
+		} else {
+			Double y_b = (Math.abs(result.getMaximum(1) - nativeRefEnv.getMaximum(1)))/resY;
+			yMax =  nativeRefEnv.getMaximum(1) - (y_b.intValue() * resY);   }
+
+		String bbox = Double.toString(xMin) + "," + Double.toString(yMin) + "," + Double.toString(xMax) + "," + Double.toString(yMax);
+		// Calculate width and height from bbox differences and resolutions
+		Double dwidth = (Math.abs(xMax - xMin))/resX;
+		Double dheight = (Math.abs(yMax - yMin))/resY;
+		int width = dwidth.intValue();
+		int height = dheight.intValue();
+		
+		String widthHeight = "&width=" + width + "&height=" + height;
+		
+		    String getCoverageRequest = "service=WCS&version=" + VERSION + 
 		 		"&request=GetCoverage&coverage=" + layerName +
-				"&bbox=" + OgpUtils.referencedEnvelopeToString(result) +
+				"&bbox=" + bbox				
 				"&crs=" + coverageOffering.getSupportedCRSs().get(0) + 
-				"&format=" + outputFormat;
-		 
-		getCoverageRequest += generateSize(coverageOffering.getRectifiedGrid());
+				"&format=" + outputFormat +
+				widthHeight;
 		
     	return getCoverageRequest;
 	}
 	
-	private static String generateSize(RectifiedGrid rgrid) throws Exception{
-		Double resx = rgrid.getResx();
-		Double resy = rgrid.getResy();
-		
-		String size = "&";
-		
-		if (resx.isNaN() || resy.isNaN()){
-			Integer width = rgrid.getWidth();
-			Integer height = rgrid.getHeight();
-			if (!width.equals(null) && !height.equals(null)){
-				size += "width=";
-				size += Integer.toString(width);
-				size += "&height=";
-				size += Integer.toString(height);
-			} else {
-				throw new Exception("invalid describe coverage response....could not form getCoverage request.");
-			}
-
-		} else {
-			 size += "resx=";
-			 size += Double.toString(resx);
-			 size += "&resy=";
-			 size += Double.toString(resy);
-		}
-		 
-
-		 return size;
-	}
-
+	
 }


### PR DESCRIPTION
When GeoServer was receiving a WcsGetCoverage request where either the bounding box mins and maxs divided pixels OR if resx&resy were specified instead of width&height, it was causing a JAI warp operation which was transforming the produced raster to correspond to the bounding box.  In addition to compromising the integrity of the raster without intention, this also alters the noData values in the produced raster.

The changes proposed transform the bounding box to the raster so that the warp doesn't take place and utilize resx and resy to calculate the width and height of the requested box .

E.g.:
Previous request....
bbox=464037.9751723,3477809.4781196,470646.2581182,3485398.5767305&crs=EPSG:26912&format=geotiff&resx=1.0&resy=1.0

New request...
bbox=464037.0,3477809.0,470646.0,3485398.0&crs=EPSG:26912&format=geotiff&width=6609&height=7589