### PR TITLE
Changed broken geotools dependency

### DIFF
--- a/geoportal_1/pom.xml
+++ b/geoportal_1/pom.xml
@@ -35,7 +35,7 @@
 	<properties>
 		<org.springframework.version>4.0.3.RELEASE</org.springframework.version>
 		<org.springframework.security.version>3.2.3.RELEASE</org.springframework.security.version>
-		<geotools.version>10-SNAPSHOT</geotools.version>
+		<geotools.version>13.2</geotools.version>
 		<jackson.version>2.3.2</jackson.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Changed geotools dependency version from 10-SNAPSHOT to 13.2, the most current stable release. This allows maven to build without failure due to missing dependencies.

Tested on windows7, maven 3.3.3