### PR TITLE
Fixed 'Help' and 'About' Dialogs

### DIFF
--- a/geoportal_1/src/main/webapp/WEB-INF/views/jspf/header.jspf
+++ b/geoportal_1/src/main/webapp/WEB-INF/views/jspf/header.jspf
@@ -8,7 +8,7 @@
 		<span class="separator">|</span> 
 		<button id="userGuideLink" class="infoLinks button headerButton">Help</button>
 		<span class="separator">|</span> 
-		<button id="highlightsLink" class="infoLinks button headerButton">About</button> 
+		<button id="aboutLink" class="infoLinks button headerButton">About</button> 
 		<span class="separator">|</span> 
 		<button id="headerLogin" class="infoLinks login button headerButton">Login</button>
 	</div>

--- a/geoportal_1/src/main/webapp/WEB-INF/views/ogp_home.jsp
+++ b/geoportal_1/src/main/webapp/WEB-INF/views/ogp_home.jsp
@@ -51,6 +51,7 @@ OpenGeoportal.Config.shareBbox="${shareBbox}";
 
 	<div id="dialogs" class="hiddenElements">
 		<%@include file="jspf/about.jspf"%>
+		<%@include file="jspf/userGuide.jspf"%>
 		<%@include file="jspf/contact.jspf"%>
 	</div>
 	


### PR DESCRIPTION
I'm not sure if the functionality was deliberately removed; if it was please disregard and close request.

I reinstated the help and about dialogs. I know the help page is outdated as it was created for OGP1 but I think it is still useful. Has development moved away from OGP2 to GeoBlacklight or something else? If not, I could possibly work on updating the help page.