### PR TITLE
Ogp2m

### DIFF
--- a/geoportal_1/src/main/webapp/resources/css/structure.css
+++ b/geoportal_1/src/main/webapp/resources/css/structure.css
@@ -1824,9 +1824,13 @@ zoom: 1;
 	-moz-transform: rotate(45deg);
 	-ms-transform: rotate(45deg);
 	-o-transform: rotate(45deg);
-	tranform: rotate(45deg);
+	transform: rotate(45deg);
 	background-color: #4B8ACF;
 	/*border-bottom: 8px solid #4B8ACF;*/
 	top: -11px;
 	z-index: 999;
+}
+
+.previewedLayers .tableRow.rowHover {
+        cursor: all-scroll;
 }

--- a/geoportal_1/src/main/webapp/resources/javascript/lib/views/layerRow.js
+++ b/geoportal_1/src/main/webapp/resources/javascript/lib/views/layerRow.js
@@ -13,7 +13,7 @@ if (typeof OpenGeoportal.Views === 'undefined') {
 OpenGeoportal.Views.LayerRow = Backbone.View.extend({
 	tagName : "div",
 	className : "tableRow",
-	id      : function() { return this.model.get("LayerId") },
+	attributes : function() { return {"layerid": this.model.get("LayerId") } },
 	events : {
 		"click .viewMetadataControl" : "viewMetadata",
 		"click .previewControl" : "togglePreview",

--- a/geoportal_1/src/main/webapp/resources/javascript/lib/views/layerRow.js
+++ b/geoportal_1/src/main/webapp/resources/javascript/lib/views/layerRow.js
@@ -13,6 +13,7 @@ if (typeof OpenGeoportal.Views === 'undefined') {
 OpenGeoportal.Views.LayerRow = Backbone.View.extend({
 	tagName : "div",
 	className : "tableRow",
+	id      : function() { return this.model.get("LayerId") },
 	events : {
 		"click .viewMetadataControl" : "viewMetadata",
 		"click .previewControl" : "togglePreview",

--- a/geoportal_1/src/main/webapp/resources/javascript/lib/views/searchResultsTable.js
+++ b/geoportal_1/src/main/webapp/resources/javascript/lib/views/searchResultsTable.js
@@ -82,6 +82,7 @@ OpenGeoportal.Views.SearchResultsTable = OpenGeoportal.Views.LayerTable
 				this.setFrameHeight();
 				var scrollTarget$ = this.$el.children(".tableWrapper").children(".rowContainer");
 				scrollTarget$.off("scroll").on("scroll", function(){that.watchScroll.apply(that, arguments);});
+				this.setSortableLayers();
 				   
 			},
 			prevScrollY: 0,
@@ -123,6 +124,35 @@ OpenGeoportal.Views.SearchResultsTable = OpenGeoportal.Views.LayerTable
 				var ht = Math.ceil(jQuery(document).height() - $scrollTarget.offset().top - previewedHeight - jQuery("#footer").height());
 				$scrollTarget.height(ht);
 			},
+			
+			setSortableLayers: function(){
+                                if (this.$(".previewedLayers .rowContainer").children().size() > 0) {
+                                        this.$(".previewedLayers").css("border", "1px solid #828282");
+                                } else {
+                                        this.$(".previewedLayers").css("border", "none");
+                                };
+
+                                this.$(".previewedLayers .rowContainer").sortable({
+                                        connectWith: ".sortable",
+                                        stop:
+                                                function(event, ui) {
+                                                        var numPreviewedLayers = $(".previewedLayers .rowContainer").length;
+                                                        $(".previewedLayers .rowContainer").children(".tableRow").each( function(){
+                                                                var layerId = $(this).attr("id")
+                                                                var index = $(this).index();
+
+                                                                var zindex = (numPreviewedLayers - index) * 5 + 335  //openLayers2 sets start of layer index to 335 and increments by 5. Using this to stay equation to consistent.
+
+                                                                jQuery(document).trigger("map.zIndexChange", {
+                                                                        zIndex : zindex,
+                                                                        LayerId: layerId
+                                                                });
+                                                         });
+                                                }
+
+                                        });
+                                this.$(".previewedLayers .rowContainer").disableSelection();
+                        },
 			
 			fireSearchHandler: function(){
 				var that = this;

--- a/geoportal_1/src/main/webapp/resources/javascript/lib/views/searchResultsTable.js
+++ b/geoportal_1/src/main/webapp/resources/javascript/lib/views/searchResultsTable.js
@@ -138,7 +138,7 @@ OpenGeoportal.Views.SearchResultsTable = OpenGeoportal.Views.LayerTable
                                                 function(event, ui) {
                                                         var numPreviewedLayers = $(".previewedLayers .rowContainer").length;
                                                         $(".previewedLayers .rowContainer").children(".tableRow").each( function(){
-                                                                var layerId = $(this).attr("id")
+                                                                var layerId = $(this).attr("layerid")
                                                                 var index = $(this).index();
 
                                                                 var zindex = (numPreviewedLayers - index) * 5 + 335  //openLayers2 sets start of layer index to 335 and increments by 5. Using this to stay equation to consistent.


### PR DESCRIPTION
Allows for user to change the display order of each layer currently being previewed with simple drag and drop.  Constructs each layer div in search results with custom attribute "layerid" that hold the LayerId value returned by solr.  This is used by the sortable layers function to associate the previewed layer location with the wms layer on the map.