### PR TITLE
Ogp2m

### DIFF
--- a/geoportal_1/src/main/java/org/opengeoportal/config/ogp/OgpConfig.java
+++ b/geoportal_1/src/main/java/org/opengeoportal/config/ogp/OgpConfig.java
@@ -21,8 +21,8 @@ public class OgpConfig {
 		return pageTitlePrimary;
 	}
 
-	public void setPageTitlePrimary(String pageTitle) {
-		this.pageTitlePrimary = pageTitle;
+	public void setPageTitlePrimary(String pageTitlePrimary) {
+		this.pageTitlePrimary = pageTitlePrimary;
 	}
 	
 	public String getPageTitleOffset() {

--- a/geoportal_1/src/main/webapp/WEB-INF/views/ogp_home.jsp
+++ b/geoportal_1/src/main/webapp/WEB-INF/views/ogp_home.jsp
@@ -5,7 +5,7 @@
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<title>${pageTitle.primary} ${pageTitle.offset}</title>
+	<title>${titlePrimary} ${titleOffset}</title>
 	<!-- add analyticsId, searchUrl, login info here -->
 	<script>
 	


### PR DESCRIPTION
Differences in page title variable names between java and jsp aren't allowing page title to populate from ogp.properties file